### PR TITLE
Add image based on Fedora 36

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,48 @@
+name: "Build Docker Image"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/fedora-36
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=short
+          flavor: |
+            latest=true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}    # Do not push if this is a pull request
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,3 +1,8 @@
+# GitHub workflow file to generate Docker images automatically.
+#
+# Copyright (C) 2022, Red Hat, Inc.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
 name: "Build Docker Image"
 
 on:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,7 +9,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/fedora-36
+  BUILD_IMAGE: ghcr.io/${{ github.repository }}/fedora-36-build
+  TEST_IMAGE: ghcr.io/${{ github.repository }}/fedora-36-test
 
 jobs:
   build-and-push-image:
@@ -29,20 +30,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,format=short
-          flavor: |
-            latest=true
+      - name: Set tag
+        run: echo "short_sha=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ github.ref == 'refs/heads/main' }}    # Do not push if this is a pull request
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build
+        run: |
+          docker build --target build --tag "${BUILD_IMAGE}:${short_sha}" - < Dockerfile
+          docker build --target test --tag "${TEST_IMAGE}:${short_sha}" - < Dockerfile
+        shell: bash
+
+      - name: Push
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker push "${BUILD_IMAGE}:${short_sha}"
+          docker push "${TEST_IMAGE}:${short_sha}"
+        shell: bash
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM registry.fedoraproject.org/fedora-minimal:36
+
+RUN microdnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        acpica-tools \
+        g++ \
+        gcc \
+        gcc-aarch64-linux-gnu \
+        gcc-arm-linux-gnu \
+        gcc-riscv64-linux-gnu \
+        git \
+        libX11-devel \
+        libXext-devel \
+        libuuid-devel \
+        make \
+        nuget \
+        nasm \
+        python \
+        python3-distutils-extra \
+        python3-pip \
+        python3-setuptools \
+        qemu-system-aarch64-core \
+        qemu-system-arm-core \
+        qemu-system-x86-core
+
+RUN pip install pip --upgrade
+
+ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
+ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:36
-
+FROM registry.fedoraproject.org/fedora-minimal:36 AS build
 RUN microdnf \
       --assumeyes \
       --nodocs \
@@ -21,13 +20,21 @@ RUN microdnf \
         python \
         python3-distutils-extra \
         python3-pip \
-        python3-setuptools \
+        python3-setuptools
+RUN pip install pip --upgrade
+ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
+ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+
+
+FROM build AS test
+RUN microdnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
         qemu-system-aarch64-core \
         qemu-system-arm-core \
         qemu-system-x86-core
 
-RUN pip install pip --upgrade
 
-ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
-ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
-ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+# Dockerfile for building container images for use in the EDK2 CI.
+#
+# Copyright (C) 2022, Red Hat, Inc.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# This file contains the definitions for images to be used for different
+# jobs in the EDK2 CI pipeline. The set of tools and dependencies is split into
+# multiple images to reduce the overall download size by providing images 
+# tailored to the task of the CI job. Currently there are two images: "build"
+# and "test".
+# The images are indented to run on x86_64.
+
+
+# Build Image
+# This image is intended for jobs that compile the source code and as a general
+# purpose image. It contains the toolchains for all supported architectures, and
+# all build dependencies.
 FROM registry.fedoraproject.org/fedora-minimal:36 AS build
 RUN microdnf \
       --assumeyes \
@@ -27,6 +44,10 @@ ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
 ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
 
 
+# Test Image
+# This image is indented for jobs that run tests (and possibly also build)
+# firmware images. It is based on the build image and adds Qemu for the
+# architectures under test.
 FROM build AS test
 RUN microdnf \
       --assumeyes \
@@ -36,5 +57,4 @@ RUN microdnf \
         qemu-system-aarch64-core \
         qemu-system-arm-core \
         qemu-system-x86-core
-
 


### PR DESCRIPTION
Add a Dockerfile for an image based on Fedora 36, containing gcc 12,
qemu, and other tools needed to run the EDK2 CI.

Also put GitHub Action in place that builds the image and pushes it to
the GitHub image registry (ghcr.io). The image shows up under "Packages"
on the GitHub page as well. The image is only pushed for changes on the
main branch. Pull Requests build the image, but do not push it.
