### PR TITLE
Switch to Fedora 35

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -14,8 +14,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BUILD_IMAGE: ghcr.io/${{ github.repository }}/fedora-36-build
-  TEST_IMAGE: ghcr.io/${{ github.repository }}/fedora-36-test
+  BUILD_IMAGE: ghcr.io/${{ github.repository }}/fedora-35-build
+  TEST_IMAGE: ghcr.io/${{ github.repository }}/fedora-35-test
 
 jobs:
   build-and-push-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # This image is intended for jobs that compile the source code and as a general
 # purpose image. It contains the toolchains for all supported architectures, and
 # all build dependencies.
-FROM registry.fedoraproject.org/fedora-minimal:36 AS build
+FROM registry.fedoraproject.org/fedora-minimal:35 AS build
 RUN microdnf \
       --assumeyes \
       --nodocs \


### PR DESCRIPTION
# Description

Use Fedora 35 as base image, since it provides GCC 11.
EDK2 can not be built with GCC 12 for RiscV64, due to
a bug (missing fence.i instruction).

Also rename the resulting images accordingly.

### Containers Affected

- fedora-36-build
- fedora-36-test
