### PR TITLE
Add latest tag to images

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -47,8 +47,13 @@ jobs:
       - name: Push
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
+          docker tag "${BUILD_IMAGE}:${short_sha}" "${BUILD_IMAGE}:latest"
           docker push "${BUILD_IMAGE}:${short_sha}"
+          docker push "${BUILD_IMAGE}:latest"
+
+          docker tag "${TEST_IMAGE}:${short_sha}" "${TEST_IMAGE}:latest"
           docker push "${TEST_IMAGE}:${short_sha}"
+          docker push "${TEST_IMAGE}:latest"
         shell: bash
 
 


### PR DESCRIPTION
Additionally tag images that are pushed as "latest".

# Description

Currently images are only tagged with the commit sha.
Image repositories are usually expected to have the 
'latest' tag pointing to the newest image.

Issue #6

### Containers Affected
(no functional changes)

- Fedora-35-build
- Fedora-35-test

