### PR TITLE
Fixed package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,25 +16,28 @@
 # purpose image. It contains the toolchains for all supported architectures, and
 # all build dependencies.
 FROM registry.fedoraproject.org/fedora-minimal:35 AS build
+ENV GCC_VERSION=11.2.1-1.fc35
+ENV NASM_VERSION=2.15.05-1.fc35
+ENV PYTHON_VERSION=3.10
 RUN microdnf \
       --assumeyes \
       --nodocs \
       --setopt=install_weak_deps=0 \
       install \
         acpica-tools \
-        gcc-c++\
-        gcc \
-        gcc-aarch64-linux-gnu \
-        gcc-arm-linux-gnu \
-        gcc-riscv64-linux-gnu \
+        gcc-c++-${GCC_VERSION} \
+        gcc-${GCC_VERSION} \
+        gcc-aarch64-linux-gnu-${GCC_VERSION} \
+        gcc-arm-linux-gnu-${GCC_VERSION} \
+        gcc-riscv64-linux-gnu-${GCC_VERSION} \
         git \
         libX11-devel \
         libXext-devel \
         libuuid-devel \
         make \
         nuget \
-        nasm \
-        python \
+        nasm-${NASM_VERSION} \
+        python${PYTHON_VERSION} \
         python3-distutils-extra \
         python3-pip \
         python3-setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN microdnf \
       --setopt=install_weak_deps=0 \
       install \
         acpica-tools \
-        g++ \
+        gcc-c++\
         gcc \
         gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN microdnf \
         python3-distutils-extra \
         python3-pip \
         python3-setuptools
+RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
 ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 FROM registry.fedoraproject.org/fedora-minimal:35 AS build
 ENV GCC_VERSION=11.2.1-1.fc35
 ENV NASM_VERSION=2.15.05-1.fc35
-ENV PYTHON_VERSION=3.10
+ENV PYTHON_VERSION=3.9
 RUN microdnf \
       --assumeyes \
       --nodocs \


### PR DESCRIPTION
# Description

Pin the versions of gcc, iasl, and nasm on the Dockerfile to avoid unnoticed upgrades during image rebuild.

Test run of the EDK2 CI with these images:
- https://github.com/tianocore/edk2/pull/3082

Issue:
- #8 

### Containers Affected

- Fedora 35 build and test image
