### PR TITLE
Python3.10 and remove acpica

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN microdnf \
       --nodocs \
       --setopt=install_weak_deps=0 \
       install \
-        acpica-tools \
         gcc-c++-${GCC_VERSION} \
         gcc-${GCC_VERSION} \
         gcc-aarch64-linux-gnu-${GCC_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 FROM registry.fedoraproject.org/fedora-minimal:35 AS build
 ENV GCC_VERSION=11.2.1-1.fc35
 ENV NASM_VERSION=2.15.05-1.fc35
-ENV PYTHON_VERSION=3.9
+ENV PYTHON_VERSION=3.10
 RUN microdnf \
       --assumeyes \
       --nodocs \


### PR DESCRIPTION
# Description

As discussed in the EDK2 Tools and CI meeting Aug 8, 2022:
- remove acpica-tools package. Let the CI pull this at run-time
- Upgrade to Python 3.10. We do not hit the tar-unpacking bug.

Test CI run with
- https://github.com/tianocore/edk2/pull/3186

### Containers Affected
- Fedora 35 build and test images
