### PR TITLE
Add EDK2 test build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -59,7 +59,8 @@ jobs:
           done
         shell: bash
 
-      - name: Check
+      - name: Check (Linux)
+        if: runner.os == 'Linux'
         run: |
           # Only check the last sub-image in the list (for now)
           sub=${SUB_IMAGES##* }

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -59,6 +59,20 @@ jobs:
           done
         shell: bash
 
+      - name: Check
+        run: |
+          # Only check the last sub-image in the list (for now)
+          sub=${SUB_IMAGES##* }
+          IMG=$(tr '[:upper:]' '[:lower:]' <<< "${REGISTRY}/${REPOSITORY}/${IMAGE_NAME}-${sub}:${short_sha}")
+          echo "Launching ${IMG}..."
+          docker run \
+            --rm \
+            --volume "${PWD}":/work \
+            --workdir /work \
+            "${IMG}" \
+            "./.github/workflows/test_build_edk2.sh"
+        shell: bash
+
       - name: Push
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/test_build_edk2.sh
+++ b/.github/workflows/test_build_edk2.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Simple smoke-test build of EDK2
+
+set -e
+set -x
+
+if [ -d edk2 ]; then
+  echo "Reusing existing EDK2 source tree."
+  cd edk2
+  echo "  Cleaning up..."
+  git fetch --all
+  git reset --hard origin/master
+  git clean -xdf
+else
+  echo "Pulling fresh EDK2 source tree."
+  git clone --depth=1 "https://github.com/tianocore/edk2.git"
+  cd edk2
+fi
+
+# fixups / workarounds:
+#   removing these files will use gcc from the image and not download it and
+#   run into the python tar bug.
+rm -f BaseTools/Bin/gcc_arm_linux_ext_dep.yaml BaseTools/Bin/gcc_aarch64_linux_ext_dep.yaml
+
+python -m pip install --upgrade pip
+python -m pip install --upgrade -r pip-requirements.txt
+
+stuart_setup -c .pytool/CISettings.py
+stuart_update -c .pytool/CISettings.py
+
+python BaseTools/Edk2ToolsBuild.py -t GCC5
+
+build_step() {
+  build=$1
+  arch=$2
+  opts="TOOL_CHAIN_TAG=GCC5"
+  echo "-----------------------------------------------------------------------"
+  echo "Building ${build} for ${arch}"
+  echo "-----------------------------------------------------------------------"
+  stuart_setup $opts -c "${build}" -a "${arch}"
+  stuart_update $opts -c "${build}" -a "${arch}"
+  stuart_build $opts -c "${build}" -a "${arch}"
+}
+
+build_step "OvmfPkg/PlatformCI/PlatformBuild.py"    "X64"
+build_step "ArmVirtPkg/PlatformCI/PlatformBuild.py" "AARCH64"
+build_step "ArmVirtPkg/PlatformCI/PlatformBuild.py" "ARM"


### PR DESCRIPTION
# Description
CI:
Run a build of OvmfPkg/ArmVirtPkg on images created via the GitHub workflow.
This serves as a very basic smoke-test to see if the imge is able to
build EDK2.

It uses stuart to build OvmfPkg for X64, and ArmVirtPkg for AARCH64 and
ARM.

For now, only the last sub-image (aka target) in the list for each
image is tested.

Note: contains a workaround. The external dependency files or AARCH64 and
ARM compilers are removed, so that the ones supplied by the image are
used. Currently, stuart on the EDK2 master branch downloads all tools
at runtime. This workaround can be removed later.

Closes #17

### Containers Affected

All Linux images.
