### PR TITLE
Add sudo to fedora to allow tool installation in azure pipelines

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -52,8 +52,6 @@ ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
 # Tools used by build extensions.
 RUN npm install -g npm markdownlint-cli cspell
 
-USER root
-
 # Test Image
 # This image is indented for jobs that run tests (and possibly also build)
 # firmware images. It is based on the build image and adds Qemu for the

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -41,7 +41,8 @@ RUN microdnf \
         python3-pip \
         python3-setuptools \
         nodejs \
-        npm
+        npm \
+        sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
@@ -50,6 +51,8 @@ ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
 
 # Tools used by build extensions.
 RUN npm install -g npm markdownlint-cli cspell
+
+USER root
 
 # Test Image
 # This image is indented for jobs that run tests (and possibly also build)


### PR DESCRIPTION
# Description

Add sudo tool to baseline of fedora image. This is required to allow non-root users, such as the one created by azure pipelines, to run command requiring root, such as microdnf or rpm to install customized pipeline tools. This is needed as some pipelines leverage powershell or other tools that aren't needed as part of the core build requirements.

Issue #27 

### Containers Affected

Fedora-*
