### PR TITLE
Missing fixes for Fedora images to run the CI 

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -19,6 +19,7 @@ FROM registry.fedoraproject.org/fedora-minimal:35 AS build
 ENV GCC_VERSION=11.2.1-1.fc35
 ENV NASM_VERSION=2.15.05-1.fc35
 ENV PYTHON_VERSION=3.10
+ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/download/2022.09.06/loongarch64-clfs-6.3-cross-tools-c-only.tar.xz"
 RUN microdnf \
       --assumeyes \
       --nodocs \
@@ -42,12 +43,19 @@ RUN microdnf \
         python3-setuptools \
         nodejs \
         npm \
+        tar \
         sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
+
+RUN mkdir -p /cross-tools/ && \
+      curl -L "${GCC_LOONGARCH64_URL}" | \
+      tar --extract -z --strip-components=1 -C /cross-tools
+
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
 ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
 ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+ENV GCC5_LOONGARCH64_PREFIX /cross-tools/bin/loongarch64-unknown-linux-gnu-
 
 # Tools used by build extensions.
 RUN npm install -g npm markdownlint-cli cspell

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -25,6 +25,7 @@ RUN microdnf \
       --nodocs \
       --setopt=install_weak_deps=0 \
       install \
+        acpica-tools \
         gcc-c++-${GCC_VERSION} \
         gcc-${GCC_VERSION} \
         gcc-aarch64-linux-gnu-${GCC_VERSION} \

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -86,7 +86,7 @@ RUN microdnf \
     mkdir -p qemu-build && cd qemu-build && \
     curl "${QEMU_URL}" | \
     tar --extract --strip-components=1 -J && \
-    ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu && \
+    ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,loongarch64-softmmu && \
     make install -j $(nproc) && \
     rm -rf qemu-build && \
     microdnf \


### PR DESCRIPTION
A collection of fixes for the Fedora 35 image(s) to make them
fit for the EDK2 CI.

# Description

- Add LoongArch64 gcc (Download from GitHub release page)
- Add Qemu for LoongArch64
- Add acpica-tools package (for iasl)

### Containers Affected

Fedora-35-*
