### PR TITLE
Add a bashrc file for root in Fedora-35-dev

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -52,8 +52,6 @@ ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
 # Tools used by build extensions.
 RUN npm install -g npm markdownlint-cli cspell
 
-USER root
-
 # Test Image
 # This image is indented for jobs that run tests (and possibly also build)
 # firmware images. It is based on the build image and adds Qemu for the

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -84,3 +84,4 @@ RUN microdnf \
 RUN wget ${GCM_LINK} -O gcm.tar.gz && tar -xvf gcm.tar.gz -C /usr/local/bin && rm gcm.tar.gz
 RUN git-credential-manager-core configure
 RUN git config --global credential.credentialStore cache
+RUN cp /etc/skel/.bashrc /root/.bashrc

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -41,7 +41,8 @@ RUN microdnf \
         python3-pip \
         python3-setuptools \
         nodejs \
-        npm
+        npm \
+        sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
@@ -50,6 +51,8 @@ ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
 
 # Tools used by build extensions.
 RUN npm install -g npm markdownlint-cli cspell
+
+USER root
 
 # Test Image
 # This image is indented for jobs that run tests (and possibly also build)


### PR DESCRIPTION
# Description

Adds a bashrc file for root to avoid warnings when launching through the VS code extension

### Containers Affected

Fedora-35-dev
