### PR TITLE
Fedora-35: Add Powershell to build image

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -22,6 +22,7 @@ ARG PYTHON_VERSION=3.10
 ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/download/2022.09.06/loongarch64-clfs-6.3-cross-tools-c-only.tar.xz"
 ARG CSPELL_VERSION=5.20.0
 ARG MARKDOWNLINT_VERSION=0.31.0
+ARG POWERSHELL_VERSION=7.3.1
 RUN dnf \
       --assumeyes \
       --nodocs \
@@ -40,6 +41,7 @@ RUN dnf \
         make \
         nuget \
         nasm-${NASM_VERSION} \
+        https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-1.rh.x86_64.rpm \
         python${PYTHON_VERSION} \
         python3-distutils-extra \
         python3-pip \


### PR DESCRIPTION
# Description

The build image is used for building in pipelines. Pipelines are
executed in Azure DevOps and most commonly used Azure-hosted VM
images. Those images come with Powershell installed.

Example:
https://github.com/actions/runner-images/blob/ubuntu22/20230109.1/images/linux/Ubuntu2204-Readme.md#powershell-tools

Further, the Azure Pipelines PowerShell@2 task supports Linux, macOS,
and Windows.

https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/powershell-v2?view=azure-pipelines

Therefore, pipeline scripts written in Powershell are already built
for cross-platform support.

This change adds Powershell to the build container image so it is
available within build environments.

Based on local testing, this increased the container image size from:
  1.55GB to 1.79GB

This seemed reasonable for the increase in functionality that is
enabled.

Issue #51

### Containers Affected

- Fedora 35

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>