### PR TITLE
Ubuntu-20: Fix dev image entrypoint

### DIFF
--- a/Ubuntu-20/Dockerfile
+++ b/Ubuntu-20/Dockerfile
@@ -168,7 +168,7 @@ RUN apt-get update && \
         vim \
         nano \
         bear &&\
-    apt-get clean \
+    apt-get clean
 
 # Setup the entry point
 COPY ubuntu20_dev_entrypoint.sh /usr/libexec/entrypoint


### PR DESCRIPTION
An extra backslash on the previous RUN, absorbed the entrypoint COPY. The result was that the entrypoint script was not copied into the image.

This results Issue #54.