### PR TITLE
Add dotnet runtime to fedora build for unittest and code coverage

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -51,8 +51,7 @@ RUN dnf \
         npm \
         tar \
         sudo \
-        dotnet-runtime-${DOTNET_VERSION} \
-        dotnet-sdk-${DOTNET_VERSION}.x86_64
+        dotnet-runtime-${DOTNET_VERSION}
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -51,7 +51,7 @@ RUN dnf \
         nodejs \
         npm \
         tar \
-        sudo \
+        sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -30,6 +30,7 @@ RUN dnf \
       --setopt=install_weak_deps=0 \
       install \
         acpica-tools \
+        dotnet-runtime-${DOTNET_VERSION} \
         gcc-c++-${GCC_VERSION} \
         gcc-${GCC_VERSION} \
         gcc-aarch64-linux-gnu-${GCC_VERSION} \
@@ -51,7 +52,6 @@ RUN dnf \
         npm \
         tar \
         sudo \
-        dotnet-runtime-${DOTNET_VERSION}
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -51,7 +51,8 @@ RUN dnf \
         npm \
         tar \
         sudo \
-        dotnet-runtime-${DOTNET_VERSION}
+        dotnet-runtime-${DOTNET_VERSION} \
+        dotnet-sdk-${DOTNET_VERSION}.x86_64
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -23,6 +23,7 @@ ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/downlo
 ARG CSPELL_VERSION=5.20.0
 ARG MARKDOWNLINT_VERSION=0.31.0
 ARG POWERSHELL_VERSION=7.3.1
+ARG DOTNET_VERSION=6.0
 RUN dnf \
       --assumeyes \
       --nodocs \
@@ -49,7 +50,8 @@ RUN dnf \
         nodejs \
         npm \
         tar \
-        sudo
+        sudo \
+        dotnet-runtime-${DOTNET_VERSION}
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install pip --upgrade
 


### PR DESCRIPTION
# Description

Adds donet runtime 6.0 to the fedora images to enable unit test and code coverage usage.

### Containers Affected

Fedora-35-*
