### PR TITLE
Fix platform build file name for EDK2 change

### DIFF
--- a/.github/workflows/test_build_edk2.sh
+++ b/.github/workflows/test_build_edk2.sh
@@ -45,6 +45,6 @@ build_step() {
   stuart_build $opts -c "${build}" -a "${arch}"
 }
 
-build_step "OvmfPkg/PlatformCI/PlatformBuild.py"    "X64"
-build_step "ArmVirtPkg/PlatformCI/PlatformBuild.py" "AARCH64"
-build_step "ArmVirtPkg/PlatformCI/PlatformBuild.py" "ARM"
+build_step "OvmfPkg/PlatformCI/PlatformBuild.py"  "X64"
+build_step "ArmVirtPkg/PlatformCI/QemuBuild.py"   "AARCH64"
+build_step "ArmVirtPkg/PlatformCI/QemuBuild.py"   "ARM"

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -23,6 +23,9 @@ ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/downlo
 ARG CSPELL_VERSION=5.20.0
 ARG MARKDOWNLINT_VERSION=0.31.0
 ARG POWERSHELL_VERSION=7.3.1
+
+# TEST WILL REMOVE!!!
+
 RUN dnf \
       --assumeyes \
       --nodocs \

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -23,9 +23,6 @@ ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/downlo
 ARG CSPELL_VERSION=5.20.0
 ARG MARKDOWNLINT_VERSION=0.31.0
 ARG POWERSHELL_VERSION=7.3.1
-
-# TEST WILL REMOVE!!!
-
 RUN dnf \
       --assumeyes \
       --nodocs \


### PR DESCRIPTION
# Description

The EDK2 commit https://github.com/tianocore/edk2/commit/01a06884a173a40bde00d2bdbf9d89224a4b00f4 changes the platform build file name for arm platform package. This updated the build script to account for this.

### Containers Affected

None - CI pipeline change only
