### PR TITLE
Fedora: install code coverage tools for GCC

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -37,6 +37,7 @@ RUN dnf \
         gcc-arm-linux-gnu-${GCC_VERSION} \
         gcc-riscv64-linux-gnu-${GCC_VERSION} \
         git \
+        lcov \
         libX11-devel \
         libXext-devel \
         libuuid-devel \
@@ -53,7 +54,7 @@ RUN dnf \
         tar \
         sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN pip install pip --upgrade
+RUN pip install pip lcov_cobertura --upgrade
 
 RUN mkdir -p /cross-tools/ && \
       curl -L "${GCC_LOONGARCH64_URL}" | \

--- a/Fedora-37/Dockerfile
+++ b/Fedora-37/Dockerfile
@@ -39,6 +39,7 @@ RUN dnf \
         gcc-arm-linux-gnu-${GCC_VERSION_CROSS} \
         gcc-riscv64-linux-gnu-${GCC_VERSION_CROSS} \
         git \
+        lcov \
         libX11-devel \
         libXext-devel \
         libuuid-devel \
@@ -55,7 +56,7 @@ RUN dnf \
         tar \
         sudo
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN pip install pip --upgrade
+RUN pip install pip lcov_cobertura --upgrade
 
 RUN mkdir -p /cross-tools/ && \
       curl -L "${GCC_LOONGARCH64_URL}" | \


### PR DESCRIPTION
# Description

Adds the tools used for code coverage on GCC for host based unit tests

### Containers Affected

Fedora-*

Increase of ~30 Mb
