### PR TITLE
Install lcov in all linux based image

### DIFF
--- a/Ubuntu-20/Dockerfile
+++ b/Ubuntu-20/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
         build-essential \
         uuid-dev \
         git \
+        lcov \
         nasm \
         acpica-tools \
         virtualenv \

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
         build-essential \
         uuid-dev \
         git \
+        lcov \
         nasm \
         acpica-tools \
         virtualenv \


### PR DESCRIPTION
# Description
For code coverage need to be enabled in azure pipeline, It requires for lcov install on all linux based machine.

### Containers Affected
Fedora-35-test
Fedora-35-dev
Fedora-37-test
Fedora-37-dev
Ubuntu-20-test
Ubuntu-20-dev
Ubuntu-22-test
Ubuntu-22-dev

# Description

Please include a summary of the change and which issue is fixed or feature is
added.

Issue #(issue)

### Containers Affected

Please list the container images affected by this change. Including any
containers based on the targeted dockerfile.
