### PR TITLE
Upgrade to Qemu 8, Bump GCC minor version on Fedora 

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -16,7 +16,8 @@
 # purpose image. It contains the toolchains for all supported architectures, and
 # all build dependencies.
 FROM registry.fedoraproject.org/fedora-minimal:35 AS build
-ARG GCC_VERSION=11.2.1-1.fc35
+ARG GCC_VERSION=11.3.1-3.fc35
+ARG GCC_VERSION_CROSS=11.2.1-1.fc35
 ARG NASM_VERSION=2.15.05-1.fc35
 ARG PYTHON_VERSION=3.10
 ARG GCC_LOONGARCH64_URL="https://github.com/loongson/build-tools/releases/download/2022.09.06/loongarch64-clfs-6.3-cross-tools-c-only.tar.xz"
@@ -33,9 +34,9 @@ RUN dnf \
         dotnet-runtime-${DOTNET_VERSION} \
         gcc-c++-${GCC_VERSION} \
         gcc-${GCC_VERSION} \
-        gcc-aarch64-linux-gnu-${GCC_VERSION} \
-        gcc-arm-linux-gnu-${GCC_VERSION} \
-        gcc-riscv64-linux-gnu-${GCC_VERSION} \
+        gcc-aarch64-linux-gnu-${GCC_VERSION_CROSS} \
+        gcc-arm-linux-gnu-${GCC_VERSION_CROSS} \
+        gcc-riscv64-linux-gnu-${GCC_VERSION_CROSS} \
         git \
         lcov \
         libX11-devel \

--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -78,7 +78,7 @@ RUN npm install -g npm \
 #Building qemu from source:
 FROM build AS test
 ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
-ARG QEMU_BRANCH="v7.2.0"
+ARG QEMU_BRANCH="v8.0.0"
 RUN dnf \
       --assumeyes \
       --nodocs \
@@ -96,7 +96,6 @@ RUN dnf \
         zlib-devel && \
     git clone "${QEMU_URL}" --branch "${QEMU_BRANCH}" --depth 1 qemu && \
     cd qemu && \
-    curl "https://patchwork.ozlabs.org/project/qemu-devel/patch/20230105161804.82486-1-lersek@redhat.com/mbox/" | git apply --ignore-whitespace && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,loongarch64-softmmu --enable-gtk && \
     make install -j $(nproc) && \
     rm -rf qemu-build && \

--- a/Fedora-35/Readme.md
+++ b/Fedora-35/Readme.md
@@ -15,7 +15,8 @@ The `dev` image in turn extends the `test` image and adds developer
 convenience tools, for example the git credential manager.
 
 These images include:
-- gcc 11.2.1 (x86, arm, aarch64, riscv)
+- gcc 11.3 (x86, arm, aarch64, riscv)
+- gcc 13 (LoongArch, from 2022-09-06)
 - nasm 2.15.05
 - Python 3.10
 - Qemu 8.0.0 (x86, arm ,aarch64, loongarch)

--- a/Fedora-35/Readme.md
+++ b/Fedora-35/Readme.md
@@ -18,4 +18,4 @@ These images include:
 - gcc 11.2.1 (x86, arm, aarch64, riscv)
 - nasm 2.15.05
 - Python 3.10
-- Qemu 6.10 (x86, arm ,aarch64)
+- Qemu 8.0.0 (x86, arm ,aarch64, loongarch)

--- a/Fedora-37/Dockerfile
+++ b/Fedora-37/Dockerfile
@@ -80,7 +80,7 @@ RUN npm install -g npm \
 #Building qemu from source:
 FROM build AS test
 ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
-ARG QEMU_BRANCH="v7.2.0"
+ARG QEMU_BRANCH="v8.0.0"
 RUN dnf \
       --assumeyes \
       --nodocs \
@@ -99,7 +99,6 @@ RUN dnf \
         zlib-devel && \
     git clone "${QEMU_URL}" --branch "${QEMU_BRANCH}" --depth 1 qemu && \
     cd qemu && \
-    curl "https://patchwork.ozlabs.org/project/qemu-devel/patch/20230105161804.82486-1-lersek@redhat.com/mbox/" | git apply --ignore-whitespace && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,loongarch64-softmmu --enable-gtk && \
     make install -j $(nproc) && \
     rm -rf qemu-build && \

--- a/Fedora-37/Dockerfile
+++ b/Fedora-37/Dockerfile
@@ -16,7 +16,7 @@
 # purpose image. It contains the toolchains for all supported architectures, and
 # all build dependencies.
 FROM registry.fedoraproject.org/fedora:37 AS build
-ARG GCC_VERSION=12.2.1-4.fc37
+ARG GCC_VERSION=12.3.1-1.fc37
 ARG GCC_VERSION_CROSS=12.2.1-2.fc37
 ARG NASM_VERSION=2.15.05-3.fc37
 ARG PYTHON_VERSION=3.11

--- a/Fedora-37/Readme.md
+++ b/Fedora-37/Readme.md
@@ -15,8 +15,8 @@ The `dev` image in turn extends the `test` image and adds developer
 convenience tools, for example the git credential manager.
 
 These images include:
-- gcc 12.2 (x86, arm, aarch64, riscv)
-- gcc for LoongArch (2022-09-06)
+- gcc 12.3 (x86, arm, aarch64, riscv)
+- gcc 13 (LoongArch, from 2022-09-06)
 - nasm 2.15.05
 - Python 3.11
 - Qemu 8.0.0 (x86, arm ,aarch64, loongarch)

--- a/Fedora-37/Readme.md
+++ b/Fedora-37/Readme.md
@@ -19,4 +19,4 @@ These images include:
 - gcc for LoongArch (2022-09-06)
 - nasm 2.15.05
 - Python 3.11
-- Qemu 7.2 (x86, arm ,aarch64)
+- Qemu 8.0.0 (x86, arm ,aarch64, loongarch)


### PR DESCRIPTION
# Description

Use the latest Qemu 8.0.0 for the Fedora images.

### Containers Affected

Fedora 35 and 37.
