### PR TITLE
fix:Correcting the way of deleting the qemu-build file

### DIFF
--- a/Fedora-35/Dockerfile
+++ b/Fedora-35/Dockerfile
@@ -99,7 +99,8 @@ RUN dnf \
     curl "https://patchwork.ozlabs.org/project/qemu-devel/patch/20230105161804.82486-1-lersek@redhat.com/mbox/" | git apply --ignore-whitespace && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,loongarch64-softmmu --enable-gtk && \
     make install -j $(nproc) && \
-    rm -rf qemu-build && \
+    cd .. && \
+    rm -rf qemu && \
     dnf \
       --assumeyes \
       remove \

--- a/Fedora-35/Readme.md
+++ b/Fedora-35/Readme.md
@@ -18,4 +18,4 @@ These images include:
 - gcc 11.2.1 (x86, arm, aarch64, riscv)
 - nasm 2.15.05
 - Python 3.10
-- Qemu 6.10 (x86, arm ,aarch64)
+- Qemu v7.2.0 (x86, arm ,aarch64)

--- a/Fedora-37/Dockerfile
+++ b/Fedora-37/Dockerfile
@@ -102,7 +102,8 @@ RUN dnf \
     curl "https://patchwork.ozlabs.org/project/qemu-devel/patch/20230105161804.82486-1-lersek@redhat.com/mbox/" | git apply --ignore-whitespace && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,loongarch64-softmmu --enable-gtk && \
     make install -j $(nproc) && \
-    rm -rf qemu-build && \
+    cd .. && \
+    rm -rf qemu && \
     dnf \
       --assumeyes \
       remove \

--- a/Ubuntu-20/Dockerfile
+++ b/Ubuntu-20/Dockerfile
@@ -162,6 +162,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     tar -xf qemu-7.1.0.tar.xz --strip-components=1 && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,riscv32-softmmu,riscv32-linux-user,riscv64-linux-user,riscv64-softmmu && \
     make install -j $(nproc) && \
+    cd .. && \
     rm -rf qemu-build && \
     apt remove --yes \
         ninja-build

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -151,6 +151,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     tar -xf qemu-7.1.0.tar.xz --strip-components=1 && \
     ./configure --target-list=x86_64-softmmu,arm-softmmu,aarch64-softmmu,riscv32-softmmu,riscv32-linux-user,riscv64-linux-user,riscv64-softmmu && \
     make install -j $(nproc) && \
+    cd .. && \
     rm -rf qemu-build && \
     apt remove --yes \
         ninja-build


### PR DESCRIPTION
# Description

After completing the qemu build and install, you need to enter the parent folder and then perform the delete operation.
  Previously, it was because of the `-f` option of the ` rm ` command, so even if the file was not successfully deleted, there would be no error.
  In fact, the qemu-build folder was not deleted before.

### Containers Affected
    Fedora-35
    Fedora-37
    Ubuntu-20
    Ubuntu-22