### PR TITLE
Add -l (--no-log-init) to useradd commands to avoid creating huge files

### DIFF
--- a/Fedora-37/fedora37_dev_entrypoint.sh
+++ b/Fedora-37/fedora37_dev_entrypoint.sh
@@ -39,7 +39,7 @@ user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
 groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
 #
 # - Add the user.
-useradd "${EDK2_DOCKER_USER}" -u "${user_uid}" -g "${user_gid}" \
+useradd "${EDK2_DOCKER_USER}" -l -u "${user_uid}" -g "${user_gid}" \
   -G wheel -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
 
 echo "${EDK2_DOCKER_USER}":tianocore | chpasswd

--- a/Fedora-39/fedora39_dev_entrypoint.sh
+++ b/Fedora-39/fedora39_dev_entrypoint.sh
@@ -39,7 +39,7 @@ user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
 groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
 #
 # - Add the user.
-useradd "${EDK2_DOCKER_USER}" -o -u "${user_uid}" -g "${user_gid}" \
+useradd "${EDK2_DOCKER_USER}" -l -o -u "${user_uid}" -g "${user_gid}" \
   -G wheel -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
 
 echo "${EDK2_DOCKER_USER}":tianocore | chpasswd

--- a/Ubuntu-20/ubuntu20_dev_entrypoint.sh
+++ b/Ubuntu-20/ubuntu20_dev_entrypoint.sh
@@ -43,7 +43,7 @@ user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
 groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
 #
 # - Add the user.
-useradd "${EDK2_DOCKER_USER}" -u "${user_uid}" -g "${user_gid}" \
+useradd "${EDK2_DOCKER_USER}" -l -u "${user_uid}" -g "${user_gid}" \
   -G sudo -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
 
 echo "${EDK2_DOCKER_USER}":tianocore | chpasswd

--- a/Ubuntu-22/ubuntu22_dev_entrypoint.sh
+++ b/Ubuntu-22/ubuntu22_dev_entrypoint.sh
@@ -42,7 +42,7 @@ user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
 groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
 #
 # - Add the user.
-useradd "${EDK2_DOCKER_USER}" -u "${user_uid}" -g "${user_gid}" \
+useradd "${EDK2_DOCKER_USER}" -l -u "${user_uid}" -g "${user_gid}" \
   -G sudo -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
 
 echo "${EDK2_DOCKER_USER}":tianocore | chpasswd


### PR DESCRIPTION
# Description

Without the -l (--no-log-init) parameter when running useradd, it can create huge /var/log/faillog and /var/log/lastlog files since it reserves space for all users between 0 and the UID.

See https://github.com/docker/hub-feedback/issues/2263#issuecomment-1205423533 for more information.

Issue #(issue)

### Containers Affected

Fedora-37
Fedora-39
Ubuntu-20
Ubuntu-22
