### PR TITLE
Ubuntu-22: Add initial support for multi-platform builds

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -61,7 +61,7 @@ jobs:
           for sub in $SUB_IMAGES; do
             IMG=$(tr '[:upper:]' '[:lower:]' <<< "${REGISTRY}/${REPOSITORY}/${IMAGE_NAME}-${sub}")
             echo "Building Image: ${IMG}:${short_sha}..."
-            docker build --target "${sub}" --tag "${IMG}:${short_sha}" -f Dockerfile .
+            docker build --target "${sub}" --platform linux/amd64 --tag "${IMG}:${short_sha}" -f Dockerfile .
           done
           docker images
         shell: bash

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -49,11 +49,21 @@ RUN apt-get update && \
         python3-venv \
         locales \
         gnupg \
-        ca-certificates && \
+        ca-certificates
+
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     apt-get install --yes --no-install-recommends \
+        g++-${GCC_MAJOR_VERSION}-aarch64-linux-gnu gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu; \
+    fi
+
+RUN if [ "TARGETPLATFORM" = "linux/arm64" ]; then \
+    apt-get install --yes --no-install-recommends \
+        g++-${GCC_MAJOR_VERSION}-x86-64-linux-gnu gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnu; \
+    fi
+
+RUN apt-get install --yes --no-install-recommends \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
         g++-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
-        g++-${GCC_MAJOR_VERSION}-aarch64-linux-gnu gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
         g++-${GCC_MAJOR_VERSION}-riscv64-linux-gnu gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \
         g++-${GCC_MAJOR_VERSION}-arm-linux-gnueabi gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabi \
         g++-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf && \


### PR DESCRIPTION
# Description

When running on AArch64 (arm64) systems, it would be nice to be able to run native Docker containers: with Apple, ASRock Rack and ADLINK selling fast Arm computers nowadays, more and more people will be running on Arm.

Add initial support for multi-platform builds:

1. Update the Ubuntu-22 Dockerfile to handle both amd64 and arm64, installing the appropriate native and cross compilers.
2. Update build-image.yaml to explitly build the amd64 container.

I'm only updating the Ubuntu-22 Dockerfile at the moment to get initial feedback on whether this change is good or not.

Issue #(issue)

### Containers Affected

Ubuntu-22
