### PR TITLE
Ubuntu-22: Update entrypoint to run as non-root on macOS

### DIFF
--- a/Ubuntu-22/Readme.md
+++ b/Ubuntu-22/Readme.md
@@ -7,6 +7,8 @@ It can be run like this:
 ```
 docker run -it \
        -v "${HOME}":"${HOME}" -e EDK2_DOCKER_USER_HOME="${HOME}" \
+       -e EDK2_DOCKER_USER="$(whoami)" -e EDK2_DOCKER_UID="$(id -u)" \
+       -e EDK2_DOCKER_GID="$(id -g)" \
        ghcr.io/tianocore/containers/ubuntu-22-dev:latest /bin/bash
 ```
 
@@ -14,6 +16,8 @@ To enter the container as 'root', prepend the command to run with `su`, for exam
 ```
 docker run -it \
        -v "${HOME}":"${HOME}" -e EDK2_DOCKER_USER_HOME="${HOME}" \
+       -e EDK2_DOCKER_USER="$(whoami)" -e EDK2_DOCKER_UID="$(id -u)" \
+       -e EDK2_DOCKER_GID="$(id -g)" \
        ghcr.io/tianocore/containers/ubuntu-22-dev:latest su /bin/bash
 ```
 

--- a/Ubuntu-22/ubuntu22_dev_entrypoint.sh
+++ b/Ubuntu-22/ubuntu22_dev_entrypoint.sh
@@ -35,10 +35,20 @@ EDK2_DOCKER_USER=${EDK2_DOCKER_USER:-edk2}
 # - Get the uid and gid from the user's home directory.
 user_uid=$(stat -c "%u" "${EDK2_DOCKER_USER_HOME}")
 user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
+
+if [ ${user_uid} -eq 0 ] && [ -n "${EDK2_DOCKER_UID}" ]; then
+  user_uid=${EDK2_DOCKER_UID}
+fi
+
+if [ ${user_gid} -eq 0 ] && [ -n "${EDK2_DOCKER_GID}" ]; then
+  user_gid=${EDK2_DOCKER_GID}
+fi
+
 #
 # - Add the group.  We'll take a shortcut here and always name it the same as
 # the username.  The name is cosmetic, though.  The important thing is that the
 # gid matches.
+groupdel $(getent group "${user_gid}" | awk -F ':' '{print $1}') || true
 groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
 #
 # - Add the user.


### PR DESCRIPTION
# Description

On macOS (and Windows), docker containers run as a more heavyweight VM unlike on Linux. One effect of this is that the code in the entrypoint script will see the UID and GID of the home directory as 0 and try to create a user with UID 0.

Work around this limitation by allowing users to pass in the UID and GID when running the container. Update the Readme.md to suggest using `$(id -u)` and `$(id -g)`.

Issue #(issue)

### Containers Affected

Ubuntu-22
