### PR TITLE
Add Fedora 40

### DIFF
--- a/.github/workflows/Fedora-40.yaml
+++ b/.github/workflows/Fedora-40.yaml
@@ -1,0 +1,27 @@
+# GitHub Action Workflow for building the Fedora 40 images.
+
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: "Fedora 40 Images"
+
+# This workflow only runs (on the main branch or on PRs targeted
+# at the main branch) and if files inside the Fedora-39 directory
+# have been modifed/added/removed...
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Fedora-40/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Fedora-40/**'
+
+jobs:
+  Build_Image:
+      uses: ./.github/workflows/build-image.yaml
+      with:
+        image_name: "Fedora-40"
+        sub_images: "build test dev"

--- a/Fedora-40/Dockerfile
+++ b/Fedora-40/Dockerfile
@@ -1,0 +1,126 @@
+# Dockerfile for building container images for use in the EDK2 CI.
+#
+# Copyright (C) 2022, Red Hat, Inc.
+# Copyright (c) 2023 Loongson Technology Corporation Limited. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# This file contains the definitions for images to be used for different
+# jobs in the EDK2 CI pipeline. The set of tools and dependencies is split into
+# multiple images to reduce the overall download size by providing images
+# tailored to the task of the CI job. Currently there are two images: "build"
+# and "test".
+# The images are intended to run on x86_64.
+
+
+# Build Image
+# This image is intended for jobs that compile the source code and as a general
+# purpose image. It contains the toolchains for all supported architectures, and
+# all build dependencies.
+FROM registry.fedoraproject.org/fedora:40 AS build
+
+# Preinstall python + dependencies as virtual environment
+RUN dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+      python3 \
+      python3-virtualenv
+RUN virtualenv /opt/venv
+ENV VIRTUAL_ENV /opt/venv
+ENV PATH /opt/venv/bin:$PATH
+RUN pip install --upgrade pip \
+        -r "https://raw.githubusercontent.com/tianocore/edk2/master/pip-requirements.txt"
+
+
+ARG CSPELL_VERSION=8.0.0
+ARG MARKDOWNLINT_VERSION=0.37.0
+ARG POWERSHELL_VERSION=7.4.1
+ARG DOTNET_VERSION=8.0
+RUN dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        acpica-tools \
+        dotnet-runtime-${DOTNET_VERSION} \
+        curl \
+        gcc-c++ \
+        gcc \
+        gcc-aarch64-linux-gnu \
+        gcc-arm-linux-gnu \
+        gcc-riscv64-linux-gnu \
+        gcc-loongarch64-linux-gnu \
+        git \
+        lcov \
+        libX11-devel \
+        libXext-devel \
+        libuuid-devel \
+        make \
+        nuget \
+        nasm \
+        https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-1.rh.x86_64.rpm \
+        python3 \
+        python3-distutils-extra \
+        python3-pip \
+        python3-devel \
+        nodejs \
+        npm \
+        tar \
+        sudo
+RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN pip install --upgrade pip lcov_cobertura setuptools
+
+ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
+ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+ENV GCC5_LOONGARCH64_PREFIX /usr/bin/loongarch64-linux-gnu-
+
+# Tools used by build extensions.
+RUN npm install -g npm \
+      cspell@${CSPELL_VERSION} \
+      markdownlint-cli@${MARKDOWNLINT_VERSION}
+
+# Test Image
+# This image is intended for jobs that run tests (and possibly also build)
+# firmware images. It is based on the build image and adds Qemu for the
+# architectures under test.
+
+FROM build AS test
+RUN dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        qemu-system-arm \
+        qemu-system-aarch64 \
+        qemu-system-loongarch64 \
+        qemu-system-x86 \
+        qemu-system-riscv \
+        qemu-ui-gtk
+
+# Dev Image
+# This image is intended for local use. This builds on the test image but adds
+# tools for local developers.
+FROM test AS dev
+ENV GCM_LINK=https://github.com/GitCredentialManager/git-credential-manager/releases/download/v2.0.785/gcm-linux_amd64.2.0.785.tar.gz
+RUN dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        libicu \
+        curl \
+        tar \
+        vim \
+        nano
+
+# Setup the git credential manager for developer credentials.
+RUN curl -L "${GCM_LINK}" | tar -xz -C /usr/local/bin
+RUN git-credential-manager-core configure
+RUN git config --global credential.credentialStore cache
+RUN cp /etc/skel/.bashrc /root/.bashrc
+
+# Set the entry point
+COPY fedora40_dev_entrypoint.sh /usr/libexec/entrypoint
+ENTRYPOINT ["/usr/libexec/entrypoint"]

--- a/Fedora-40/Readme.md
+++ b/Fedora-40/Readme.md
@@ -1,0 +1,21 @@
+# Fedora 40 Images
+
+This set of images is based on the Fedora 40 image.
+It has three flavors, `build`, `test`, and `dev`.
+The first two are primarily intended for automated builds
+and CI usage.
+
+The `build` image contains the compilers and build tools
+needed for building EDK2 under Linux (x86_64).
+
+The `test` image extends the `build` image and adds Qemu for
+testing purposes.
+
+The `dev` image in turn extends the `test` image and adds developer
+convenience tools, for example the git credential manager.
+
+These images include:
+- gcc 14.0.1 (x86, arm, aarch64, riscv, loongarch64)
+- nasm 2.16.01
+- Python 3.12.2
+- Qemu 8.2 (x86, arm, aarch64, loongarch64)

--- a/Fedora-40/fedora40_dev_entrypoint.sh
+++ b/Fedora-40/fedora40_dev_entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+set -e
+
+#####################################################################
+# Check for required env
+if [ -z "${EDK2_DOCKER_USER_HOME}" ] || [ ! -d "${EDK2_DOCKER_USER_HOME}" ]; then
+  echo 'Missing EDK2_DOCKER_USER_HOME. Running as root.'
+  exec "$@"
+fi
+
+#####################################################################
+# Create a user to run the command
+#
+# Docker would run as root, but that creates a permissions mess in a mixed
+# development environment where some commands are run inside the container and
+# some outside.  Instead, we'll create a user with uid/gid to match the one
+# running the container.  Then, the permissions will be consistent with
+# non-docker activities.
+#
+# - If the caller provides a username, we'll use it.  Otherwise, just use an
+# arbitrary username.
+EDK2_DOCKER_USER=${EDK2_DOCKER_USER:-edk2}
+#
+# - Get the uid and gid from the user's home directory.
+user_uid=$(stat -c "%u" "${EDK2_DOCKER_USER_HOME}")
+user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
+#
+# - Add the group.  We'll take a shortcut here and always name it the same as
+# the username.  The name is cosmetic, though.  The important thing is that the
+# gid matches.
+groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
+#
+# - Add the user.
+useradd "${EDK2_DOCKER_USER}" -o -l -u "${user_uid}" -g "${user_gid}" \
+  -G wheel -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
+
+echo "${EDK2_DOCKER_USER}":tianocore | chpasswd
+
+#####################################################################
+# Cleanup variables
+unset user_uid
+unset user_gid
+
+
+#####################################################################
+# Drop permissions and run the command
+if [ "$1" = "su" ]; then
+  # Special case.  Let the user come in as root, if they really want to.
+  shift
+  exec "$@"
+else
+  exec runuser -u "${EDK2_DOCKER_USER}" -- "$@"
+fi


### PR DESCRIPTION
# Description

Add images based on Fedora 40.

It includes:
- gcc 14.1.1 (x86, arm, aarch64, riscv, loongarch64)
- nasm 2.16.01
- Python 3.12.2, virtualenv is set up.
- Qemu 8.2 (x86, arm, aarch64, loongarch64)

Issue #94 

