### PR TITLE
Add clang and llvm to Fedora 40 and Ubuntu 22 dev images.

### DIFF
--- a/Fedora-40/Dockerfile
+++ b/Fedora-40/Dockerfile
@@ -110,7 +110,10 @@ RUN dnf \
       --setopt=install_weak_deps=0 \
       install \
         libicu \
+        clang \
         curl \
+        lld \
+        llvm \
         tar \
         vim \
         nano

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -174,10 +174,14 @@ FROM test AS dev
 # required.
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
-        vim \
-        nano \
+        bear \
+        clang \
         less \
-        bear &&\
+        lld \
+        llvm \
+        nano \
+        vim \
+        && \
     apt-get clean
 
 # Setup the entry point


### PR DESCRIPTION
Add clang and llvm to Fedora 40 and Ubuntu 22 dev images.
Images of older distro releases are not updated intentionally.

# Description

Clang can be useful for development. Add it to the dev images.
CI does not use clang, so no need to include it there.

Issue #99

### Containers Affected

- Fedora 40
- Ubuntu 22
