### PR TITLE
Migrate clang/llvm to build images

### DIFF
--- a/Fedora-40/Dockerfile
+++ b/Fedora-40/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf \
       install \
         acpica-tools \
         dotnet-runtime-${DOTNET_VERSION} \
+        clang \
         curl \
         gcc-c++ \
         gcc \
@@ -56,6 +57,8 @@ RUN dnf \
         libX11-devel \
         libXext-devel \
         libuuid-devel \
+        lld \
+        llvm \
         make \
         nuget \
         nasm \
@@ -110,10 +113,7 @@ RUN dnf \
       --setopt=install_weak_deps=0 \
       install \
         libicu \
-        clang \
         curl \
-        lld \
-        llvm \
         tar \
         vim \
         nano

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -66,6 +66,10 @@ RUN apt-get update && \
         g++-${GCC_MAJOR_VERSION}-riscv64-linux-gnu gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \
         g++-${GCC_MAJOR_VERSION}-arm-linux-gnueabi gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabi \
         g++-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf && \
+    apt-get install --yes --no-install-recommends \
+        clang \
+        lld \
+        llvm && \
     apt-get upgrade -y && \
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
@@ -175,10 +179,7 @@ FROM test AS dev
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         bear \
-        clang \
         less \
-        lld \
-        llvm \
         nano \
         vim \
         && \


### PR DESCRIPTION
# Description

This PR proposes moving [clang+llvm](https://github.com/tianocore/containers/pull/100) from -dev to -build, with a view to making a future PR offering CLANGDWARF and CLANGPDB CI to EDK 2.

I note that `gcc` in the Ubuntu image uses `update-alternatives` to link to a fixed version - while this is potentially somewhat fragile (i.e. there is unfortunately no automatic way to link all and only the bins provided by a given version), it does allow a fixed version. On the other hand the Fedora image doesn't use anything similar.

I haven't added a fixed version with `update-alternatives` for `clang`, though am happy to update the PR do so; with either the bins which appear to be needed to build, or all bins which seem to be provided with the given version - although this is quite an extensive list in the case of llvm-14 (75 bins).

Issue #99

### Containers Affected

ubuntu-22-build
ubuntu-22-test
ubuntu-22-dev
fedora-40-build
fedora-40-test
fedora-40-dev
