### PR TITLE
Fedora-40: Adjust ownership of Python venv

### DIFF
--- a/Fedora-40/fedora40_dev_entrypoint.sh
+++ b/Fedora-40/fedora40_dev_entrypoint.sh
@@ -40,6 +40,11 @@ useradd "${EDK2_DOCKER_USER}" -o -l -u "${user_uid}" -g "${user_gid}" \
 
 echo "${EDK2_DOCKER_USER}":tianocore | chpasswd
 
+# Adjust owner of the pre-initialized Python virtual env
+if [ -d "${VIRTUAL_ENV}" ]; then
+  chown --recursive "${EDK2_DOCKER_USER}" "${VIRTUAL_ENV}"
+fi
+
 #####################################################################
 # Cleanup variables
 unset user_uid


### PR DESCRIPTION

# Description

The image contains a pre-initialized Python virtual env. This needs to be writable to the user running the image. Since we do not know the uid at image build time, let's fix it up in the entry point script.


Issue #(issue)

### Containers Affected

Fedora 40 only.

Everything else I want to stop maintaining now.
