### PR TITLE
Add PREFIX envs for GCC toolchain

### DIFF
--- a/Fedora-40/Dockerfile
+++ b/Fedora-40/Dockerfile
@@ -73,9 +73,15 @@ RUN dnf \
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN pip install --upgrade pip lcov_cobertura setuptools
 
-ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
-ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnu-
-ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+# Set toolchains prefix
+ENV GCC_AARCH64_PREFIX      /usr/bin/aarch64-linux-gnu-
+ENV GCC_ARM_PREFIX          /usr/bin/arm-linux-gnu-
+ENV GCC_RISCV64_PREFIX      /usr/bin/riscv64-linux-gnu-
+ENV GCC_LOONGARCH64_PREFIX  /usr/bin/loongarch64-linux-gnu-
+# - Also set GCC5, which is deprecated, but still in use.
+ENV GCC5_AARCH64_PREFIX     /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX         /usr/bin/arm-linux-gnu-
+ENV GCC5_RISCV64_PREFIX     /usr/bin/riscv64-linux-gnu-
 ENV GCC5_LOONGARCH64_PREFIX /usr/bin/loongarch64-linux-gnu-
 
 # Tools used by build extensions.

--- a/Ubuntu-22/Dockerfile
+++ b/Ubuntu-22/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
 # Build ubuntu22-based container images for use when building EDK2:
@@ -113,6 +113,10 @@ RUN \
       --install /usr/bin/riscv64-linux-gnu-cpp riscv64-linux-gnu-cpp /usr/bin/riscv64-linux-gnu-cpp-${GCC_MAJOR_VERSION} 100
 
 # Set toolchains prefix
+ENV GCC_AARCH64_PREFIX  /usr/bin/aarch64-linux-gnu-
+ENV GCC_ARM_PREFIX      /usr/bin/arm-linux-gnueabi-
+ENV GCC_RISCV64_PREFIX  /usr/bin/riscv64-linux-gnu-
+# - Also set GCC5, which is deprecated, but still in use.
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
 ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnueabi-
 ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-

--- a/Ubuntu-24/Dockerfile
+++ b/Ubuntu-24/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Copyright (c) 2025 Yuki Kurosawa. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -117,6 +117,10 @@ RUN \
       --install /usr/bin/riscv64-linux-gnu-cpp riscv64-linux-gnu-cpp /usr/bin/riscv64-linux-gnu-cpp-${GCC_MAJOR_VERSION} 100
 
 # Set toolchains prefix
+ENV GCC_AARCH64_PREFIX  /usr/bin/aarch64-linux-gnu-
+ENV GCC_ARM_PREFIX      /usr/bin/arm-linux-gnueabi-
+ENV GCC_RISCV64_PREFIX  /usr/bin/riscv64-linux-gnu-
+# - Also set GCC5, which is deprecated, but still in use.
 ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
 ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnueabi-
 ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-


### PR DESCRIPTION
# Description
The GCC5 toolchain has been deprecated in favor of the GCC toolchain. Add the env needed by the GCC toolchain.

### Containers Affected

All containers.
* Fedora-40
* Ubuntu-22
* Ubuntu-24