### PR TITLE
feat: Provide Fedora-41-AArch64 container

### DIFF
--- a/.github/workflows/Fedora-41-AArch64.yaml
+++ b/.github/workflows/Fedora-41-AArch64.yaml
@@ -1,0 +1,29 @@
+# GitHub Action Workflow for building the Fedora 41 AArch64 images.
+
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: "Fedora 41 AArch64 Images"
+
+# This workflow only runs (on the main branch or on PRs targeted
+# at the main branch) and if files inside the Fedora-41 directory
+# have been modifed/added/removed...
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ '**' ]  # Match all branches
+    paths:
+      - 'Fedora-41-AArch64/**'
+
+  pull_request:
+    branches: [ '**' ]  # Match PRs targeting any branch
+    paths:
+      - 'Fedora-41-AArch64/**'
+
+jobs:
+  Build_Image:
+      uses: ./.github/workflows/build-image-AArch64.yaml
+      with:
+        image_name: "Fedora-41-AArch64"
+        sub_images: "build test dev"

--- a/.github/workflows/build-image-AArch64.yaml
+++ b/.github/workflows/build-image-AArch64.yaml
@@ -7,7 +7,7 @@
 # should have a matching top-level workflow yaml file.
 
 
-name: "Build and Push images"
+name: "Build and Push images for AArch64"
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ on:
         type: string
         required: false
         description: "The OS used to build the docker image."
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04-arm"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test_build_edk2.sh
+++ b/.github/workflows/test_build_edk2.sh
@@ -45,6 +45,8 @@ build_step() {
   stuart_build $opts -c "${build}" -a "${arch}"
 }
 
-build_step "OvmfPkg/PlatformCI/PlatformBuild.py"  "X64"
+if [ "$(uname -m)" = "x86_64" ]; then
+  build_step "OvmfPkg/PlatformCI/PlatformBuild.py" "X64"
+fi
 build_step "ArmVirtPkg/PlatformCI/QemuBuild.py"   "AARCH64"
 build_step "ArmVirtPkg/PlatformCI/QemuBuild.py"   "ARM"

--- a/Fedora-41-AArch64/Dockerfile
+++ b/Fedora-41-AArch64/Dockerfile
@@ -1,0 +1,138 @@
+# Dockerfile for building container images for use in the EDK2 CI.
+#
+# Copyright (C) 2022, Red Hat, Inc.
+# Copyright (c) 2023 Loongson Technology Corporation Limited. All rights reserved.
+# Copyright (c) 2025 Damien Chen <inkfan130924783@gmail.com>. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# This file contains the definitions for images to be used for different
+# jobs in the EDK2 CI pipeline. The set of tools and dependencies is split into
+# multiple images to reduce the overall download size by providing images
+# tailored to the task of the CI job. Currently there are two images: "build"
+# and "test".
+# The images are intended to run on AArch64.
+
+
+# Build Image
+# This image is intended for jobs that compile the source code and as a general
+# purpose image. It contains the toolchains for all supported architectures, and
+# all build dependencies.
+FROM --platform=linux/arm64 registry.fedoraproject.org/fedora:41 AS build
+
+# Preinstall python + dependencies as virtual environment
+RUN --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+      python3 \
+      python3-virtualenv
+RUN virtualenv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --upgrade pip \
+        -r "https://raw.githubusercontent.com/tianocore/edk2/master/pip-requirements.txt"
+
+
+ARG CSPELL_VERSION=8.19.2
+ARG MARKDOWNLINT_VERSION=0.44.0
+ARG POWERSHELL_VERSION=7.5.0
+ARG DOTNET_VERSION=9.0
+RUN --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        acpica-tools \
+        dotnet-runtime-${DOTNET_VERSION} \
+        curl \
+        gcc-c++ \
+        gcc \
+        gcc-x86_64-linux-gnu \
+        gcc-aarch64-linux-gnu \
+        gcc-arm-linux-gnu \
+        gcc-riscv64-linux-gnu \
+        gcc-loongarch64-linux-gnu \
+        git \
+        lcov \
+        libX11-devel \
+        libXext-devel \
+        libuuid-devel \
+        libasan \
+        libubsan \
+        make \
+        nuget \
+        nasm \
+        python3-distutils-extra \
+        python3-pip \
+        python3-devel \
+        nodejs \
+        npm \
+        tar \
+        sudo 
+RUN alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --upgrade pip lcov_cobertura setuptools
+
+# Set toolchains prefix
+ENV GCC_X64_PREFIX          /usr/bin/x86_64-linux-gnu-
+ENV GCC_AARCH64_PREFIX      /usr/bin/aarch64-linux-gnu-
+ENV GCC_ARM_PREFIX          /usr/bin/arm-linux-gnu-
+ENV GCC_RISCV64_PREFIX      /usr/bin/riscv64-linux-gnu-
+ENV GCC_LOONGARCH64_PREFIX  /usr/bin/loongarch64-linux-gnu-
+# - Also set GCC5, which is deprecated, but still in use.
+ENV GCC5_X64_PREFIX         /usr/bin/x86_64-linux-gnu-
+ENV GCC5_AARCH64_PREFIX     /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX         /usr/bin/arm-linux-gnu-
+ENV GCC5_RISCV64_PREFIX     /usr/bin/riscv64-linux-gnu-
+ENV GCC5_LOONGARCH64_PREFIX /usr/bin/loongarch64-linux-gnu-
+
+# Tools used by build extensions.
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g npm \
+      cspell@${CSPELL_VERSION} \
+      markdownlint-cli@${MARKDOWNLINT_VERSION}
+
+# Test Image
+# This image is intended for jobs that run tests (and possibly also build)
+# firmware images. It is based on the build image and adds Qemu for the
+# architectures under test.
+
+FROM build AS test
+RUN --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        qemu-system-arm \
+        qemu-system-aarch64 \
+        qemu-system-loongarch64 \
+        qemu-system-x86 \
+        qemu-system-riscv \
+        qemu-ui-gtk
+
+# Dev Image
+# This image is intended for local use. This builds on the test image but adds
+# tools for local developers.
+FROM test AS dev
+RUN --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    dnf \
+      --assumeyes \
+      --nodocs \
+      --setopt=install_weak_deps=0 \
+      install \
+        libicu \
+        clang \
+        curl \
+        lld \
+        llvm \
+        tar \
+        vim \
+        nano 
+# Set the entry point
+COPY fedora41_AArch64_dev_entrypoint.sh /usr/libexec/entrypoint
+ENTRYPOINT ["/usr/libexec/entrypoint"]

--- a/Fedora-41-AArch64/Readme.md
+++ b/Fedora-41-AArch64/Readme.md
@@ -1,0 +1,21 @@
+# Fedora 41 Images
+
+This set of images is based on the Fedora 41 image.
+It has three flavors, `build`, `test`, and `dev`.
+The first two are primarily intended for automated builds
+and CI usage.
+
+The `build` image contains the compilers and build tools
+needed for building EDK2 under Linux (AArch64).
+
+The `test` image extends the `build` image and adds Qemu for
+testing purposes.
+
+The `dev` image in turn extends the `test` image and adds developer
+convenience tools, for example the git credential manager.
+
+These images include:
+- gcc 14.2.1 (x86, arm, aarch64, riscv, loongarch64)
+- nasm 2.16.03
+- Python 3.13.3
+- Qemu 9.1.3 (x86, arm, aarch64, riscv, loongarch64)

--- a/Fedora-41-AArch64/fedora41_AArch64_dev_entrypoint.sh
+++ b/Fedora-41-AArch64/fedora41_AArch64_dev_entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+set -e
+
+#####################################################################
+# Check for required env
+if [ -z "${EDK2_DOCKER_USER_HOME}" ] || [ ! -d "${EDK2_DOCKER_USER_HOME}" ]; then
+  echo 'Missing EDK2_DOCKER_USER_HOME. Running as root.'
+  exec "$@"
+fi
+
+#####################################################################
+# Create a user to run the command
+#
+# Docker would run as root, but that creates a permissions mess in a mixed
+# development environment where some commands are run inside the container and
+# some outside.  Instead, we'll create a user with uid/gid to match the one
+# running the container.  Then, the permissions will be consistent with
+# non-docker activities.
+#
+# - If the caller provides a username, we'll use it.  Otherwise, just use an
+# arbitrary username.
+EDK2_DOCKER_USER=${EDK2_DOCKER_USER:-edk2}
+#
+# - Get the uid and gid from the user's home directory.
+user_uid=$(stat -c "%u" "${EDK2_DOCKER_USER_HOME}")
+user_gid=$(stat -c "%g" "${EDK2_DOCKER_USER_HOME}")
+#
+# - Add the group.  We'll take a shortcut here and always name it the same as
+# the username.  The name is cosmetic, though.  The important thing is that the
+# gid matches.
+groupadd "${EDK2_DOCKER_USER}" -f -o -g "${user_gid}"
+#
+# - Add the user.
+useradd "${EDK2_DOCKER_USER}" -o -l -u "${user_uid}" -g "${user_gid}" \
+  -G wheel -d "${EDK2_DOCKER_USER_HOME}" -M -s /bin/bash
+
+echo "${EDK2_DOCKER_USER}":tianocore | chpasswd
+
+# Adjust owner of the pre-initialized Python virtual env
+if [ -d "${VIRTUAL_ENV}" ]; then
+  chown --recursive "${EDK2_DOCKER_USER}" "${VIRTUAL_ENV}"
+fi
+
+#####################################################################
+# Cleanup variables
+unset user_uid
+unset user_gid
+
+
+#####################################################################
+# Drop permissions and run the command
+if [ "$1" = "su" ]; then
+  # Special case.  Let the user come in as root, if they really want to.
+  shift
+  exec "$@"
+else
+  exec runuser -u "${EDK2_DOCKER_USER}" -- "$@"
+fi


### PR DESCRIPTION
This commit introduces a new container for Fedora 41 on AArch64 architecture. It includes the necessary Dockerfile and GitHub Actions workflow to build and test the image.

# Description

- Create Fedora-41-AArch64 container for future development in ARM PC.
- Create Github Actions CI pipeline for AArch64.

Issue #(issue)
#114 

### Containers Affected
N/A
